### PR TITLE
Preserve BC for kinsta/kinsta-mu-plugins package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
-  "name": "kinsta/kinsta-mu-plugins",
-  "type": "wordpress-muplugin"
+  "name": "retlehs/kinsta-mu-plugins",
+  "type": "wordpress-muplugin",
+  "replace": {
+    "kinsta/kinsta-mu-plugins": "self.version"
+  }
 }


### PR DESCRIPTION
## Summary
- Renames the Composer package to `retlehs/kinsta-mu-plugins` so it matches the install instructions from #25
- Adds a `replace` entry for `kinsta/kinsta-mu-plugins` so existing consumers requiring the old name continue to resolve

#25 updated the README to recommend `composer require retlehs/kinsta-mu-plugins`, but `composer.json` still declared `kinsta/kinsta-mu-plugins`, so the new instructions wouldn't actually resolve and the rename would have broken anyone already requiring the old name. This catches both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)